### PR TITLE
The computation of the badge size is flawed in some circumstances: The space surrounding the label (and sometimes - by a lesser extent - also the value) is sometimes to small and some other times to large.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ ENV/
 
 .DS_Store
 demo.svg
+/pylint.svg

--- a/anybadge.py
+++ b/anybadge.py
@@ -294,7 +294,7 @@ class Badge(object):
         """
         font = ImageFont.truetype(font_manager.findfont(self.font_name), self.font_size)
         size = font.getsize(text)
-        return size[0] #len(text) * self.get_font_width(self.font_name, self.font_size)
+        return size[0]
 
     @property
     def badge_color(self):

--- a/anybadge.py
+++ b/anybadge.py
@@ -7,6 +7,8 @@ simplicity and flexibility.
 """
 import os
 import re
+from PIL import ImageFont
+import matplotlib.font_manager as font_manager
 
 # Package information
 version = __version__ = "0.1.0.dev2"
@@ -22,14 +24,6 @@ DEFAULT_FONT_SIZE = 11
 NUM_PADDING_CHARS = 0.5
 DEFAULT_COLOR = '#4c1'
 DEFAULT_TEXT_COLOR = '#fff'
-
-# Dictionary for looking up approx pixel widths of
-# supported fonts and font sizes.
-FONT_WIDTHS = {
-    'DejaVu Sans,Verdana,Geneva,sans-serif': {
-        11: 7
-    }
-}
 
 # Create a dictionary of colors to make selections
 # easier.
@@ -219,7 +213,7 @@ class Badge(object):
     def color_split_position(self):
         """The SVG x position where the color split should occur."""
         return self.get_text_width(' ') + self.label_width + \
-            int(float(self.font_width) * float(self.num_padding_chars))
+            int(float(self.get_text_width(' ')) * float(self.num_padding_chars))
 
     @property
     def label_anchor(self):
@@ -298,7 +292,9 @@ class Badge(object):
         >>> badge.get_text_width('pylint')
         42
         """
-        return len(text) * self.get_font_width(self.font_name, self.font_size)
+        font = ImageFont.truetype(font_manager.findfont(self.font_name), self.font_size)
+        size = font.getsize(text)
+        return size[0] #len(text) * self.get_font_width(self.font_name, self.font_size)
 
     @property
     def badge_color(self):
@@ -413,8 +409,7 @@ examples:
                                                           'either side of the badge text.',
                         default=NUM_PADDING_CHARS)
     parser.add_argument('-n', '--font', type=str,
-                        help='Font name.  Supported fonts: '
-                             ','.join(['"%s"' % x for x in FONT_WIDTHS.keys()]),
+                        help='Font name.',
                         default=DEFAULT_FONT)
     parser.add_argument('-z', '--font-size', type=int, help='Font size.',
                         default=DEFAULT_FONT_SIZE)


### PR DESCRIPTION
I use the solution to create dynamic badges in gitlab as the example screenshot shows:
image
![image](https://user-images.githubusercontent.com/18102857/51514356-a0a4ac00-1e0f-11e9-88c3-fd583b1f1a2b.png)

But the screenshot also shows that the space surrounding the label (and sometimes - by a lesser extent - also the value) is sometimes to small and some other times to large.

I therefore made some small changes - also introducing two newdependencies - that not only mitigate this issue but also allow to use any font installed on the system for the badges. It essentially computes the real extent of the text using the specified font - achieving results like these (the results are added as attachments):
```
python3 ./anybadge.py -l "issues not touched since last weeks" -v 100 -s "%" -f TimesNewRoman.svg -o -n "Times New Roman"
python3 ./anybadge.py -l "issues not touched since last weeks" -v 100 -s "%" -f DejaVuSans.svg -o -n "DejaVu Sans"
python3 ./anybadge.py -l "issues not touched since last weeks" -v 100 -s "%" -f Arial.svg -o -n "Arial"
python3 ./anybadge.py -l "issues not touched since last weeks" -v 100 -s "%" -f FreeMono.svg -o -n "FreeMono"
```

An interesting issue arises when the script (or matplotlib for that matter) is unable to actually find the ttf-file for the wanted font as in this example on my machine:

```
python3 ./anybadge.py -l "issues not touched since last weeks" -v 100 -s "%" -f Courier.svg -o -n "Courier"
```

It then falls back to using the font metrics of another Font (in my case it was DejaVu Sans):

```
/usr/lib/python3/dist-packages/matplotlib/font_manager.py:1320: UserWarning: findfont: Font family ['Courier'] not found. Falling back to DejaVu Sans
  (prop.get_family(), self.defaultFamily[fontext]))
```
And the result is then wrong as seen in the attached result for this case. I still think that the changes proposed here are a small improvement and would be really greatful if they were considered...

[results.zip](https://github.com/jongracecox/anybadge/files/2781450/results.zip)
