### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,8 @@ setup(
     entry_points={
         'console_scripts': ['anybadge=anybadge:main',
                             'anybadge-server=anybadge_server:main'],
-    }
+    },
+    classifiers=[
+        'License :: OSI Approved :: MIT License'
+    ]
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.