### PR TITLE
Fix widths

### DIFF
--- a/anybadge.py
+++ b/anybadge.py
@@ -395,9 +395,10 @@ class Badge(object):
 
             >>> badge = Badge('pylint', '5')
             >>> badge.badge_width
-            103
+            65
         """
-        padding = int(self.font_width * (self.num_padding_chars + 3))
+        padding_char_width = self.get_text_width(' ')
+        padding = int(padding_char_width * (self.num_padding_chars + 3))
         return padding + self.label_width + self.value_width
 
     @property

--- a/anybadge.py
+++ b/anybadge.py
@@ -20,7 +20,7 @@ __uri__ = "https://github.com/jongracecox/anybadge"
 # Set some defaults
 DEFAULT_FONT = 'DejaVu Sans,Verdana,Geneva,sans-serif'
 DEFAULT_FONT_SIZE = 11
-NUM_PADDING_CHARS = 0.5
+NUM_PADDING_CHARS = 0
 DEFAULT_COLOR = '#4c1'
 DEFAULT_TEXT_COLOR = '#fff'
 MASK_ID_PREFIX = 'anybadge_'
@@ -94,7 +94,7 @@ class Badge(object):
         value(str): Badge value text.
         font_name(str, optional): Name of font to use.
         font_size(int, optional): Font size.
-        num_padding_chars(float): Number of padding characters to use to give extra
+        num_padding_chars(float, optional): Number of padding characters to use to give extra
             space around text.
         template(str, optional): String containing the SVG template.  This should be valid SVG
             file content with place holders for variables to be populated during rendering.


### PR DESCRIPTION
Make badges narrower by changing padding character to the estimated width of a space character rather than using the maximum font character width.  This also sets the default number of padding chars to 0 due to the interest in producing more compact badges.