### PR TITLE
33 fix setup readme issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ written to stdout, so can be redirected to a file.
 Some thresholds have been built in to save time.  To use these thresholds you
 can simply specify the template name instead of threshold value/color pairs.
 
-```
+```bash
 anybadge --value=<VALUE> --file=<FILE> <TEMPLATE-NAME>
 ```
 
@@ -172,31 +172,31 @@ for color, hex in sorted(anybadge.COLORS.items()):
 ### Examples
 
 #### Pylint using template
-```
+```bash
 anybadge --value=2.22 --file=pylint.svg pylint
 ```
 ![pylint](https://cdn.rawgit.com/jongracecox/anybadge/master/examples/pylint.svg) 
 
 #### Pylint using arguments
-```
+```bash
 anybadge -l pylint -v 2.22 -f pylint.svg 2=red 4=orange 8=yellow 10=green
 ```
 ![pylint](https://cdn.rawgit.com/jongracecox/anybadge/master/examples/pylint.svg) 
 
 #### Coverage using template
-```
+```bash
 anybadge --value=65 --file=coverage.svg coverage
 ``` 
 ![pylint](https://cdn.rawgit.com/jongracecox/anybadge/master/examples/coverage.svg)
 
 #### Pipeline, using labeled colors
-```
+```bash
 anybadge --label=pipeline --value=passing --file=pipeline.svg passing=green failing=red
 ```
 ![pylint](https://cdn.rawgit.com/jongracecox/anybadge/master/examples/pipeline.svg)
 
 #### Badge with fixed color
-```
+```bash
 anybadge --label=awesomeness --value="110%" --file=awesomeness.svg --color=#97CA00
 ```
 ![pylint](https://cdn.rawgit.com/jongracecox/anybadge/master/examples/awesomeness.svg)

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,5 +1,3 @@
-m2r
-restructuredtext_lint
 pygments
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,9 @@
 import os
 import re
 from setuptools import setup
-from m2r import parse_from_file
-import restructuredtext_lint
 
-# Parser README.md into reStructuredText format
-rst_readme = parse_from_file('README.md')
-
-# Validate the README, checking for errors
-errors = restructuredtext_lint.lint(rst_readme)
-
-# Raise an exception for any errors found
-if errors:
-    print(rst_readme)
-    raise ValueError('README.md contains errors: ',
-                     ', '.join([e.message for e in errors]))
+with open('README.md', encoding='utf-8') as f:
+    long_description = f.read()
 
 # Attempt to get version number from TravisCI environment variable
 version = os.environ.get('TRAVIS_TAG', default='0.0.0')
@@ -26,7 +15,8 @@ version = re.sub('^v', '', version)
 setup(
     name='anybadge',
     description='Simple, flexible badge generator for project badges.',
-    long_description=rst_readme,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     version=version,
     author='Jon Grace-Cox',
     author_email='jongracecox@gmail.com',


### PR DESCRIPTION
This removes the conversion of the `README.md` from markdown to restructured text, and uses the new PyPI functionality allowing you to provide the `long_description` in markdown format.

Removed `m2r` and the restructured text linter from the build requirements and the setup.py.