### PR TITLE
Render badges inside notebook cells.

### DIFF
--- a/anybadge.py
+++ b/anybadge.py
@@ -276,6 +276,15 @@ class Badge(object):
             optional_args
         )
 
+    def _repr_svg_(self):
+        """Return SVG representation when used inside Jupyter notebook cells.
+        
+        This will render the SVG immediately inside a notebook cell when creating
+        a Badge instance without assigning it to an identifier.
+        """
+        return self.badge_svg_text
+    
+    
     @classmethod
     def _get_next_mask_id(cls):
         """Return a new mask ID from a singleton sequence maintained on the class.


### PR DESCRIPTION
This allows to render badges immediately in a notebook cell without using anything in addition like `IPython.display.SVG`. See sample image.

<img width="492" alt="Screenshot 2020-01-16 at 14 43 48" src="https://user-images.githubusercontent.com/1001778/72529979-ac824d00-386e-11ea-9a83-32c85b072192.png">
 