### PR TITLE
Add semantic version support (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,30 @@ for color, hex in sorted(anybadge.COLORS.items()):
     print("| {color} | {hex} | ![]({url}) |".format(color=color, hex=hex.upper(), url=url))
 ```
 
+### Semantic version support
+
+Anybadge supports semantic versions for value and threshold keys. This supports color-coded
+badges based on version numbering. Here are some examples:
+
+```python
+badge = Badge(
+    label='Version', 
+    value='3.0.0', 
+    thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, 
+    semver=True
+)
+```
+
+In the above example the thresholds equate to the following:
+
+* If value is < 3.0.0 then badge will be red.
+* If value is < 3.2.0 then badge will be orange.
+* If value is < 999.0.0 then badge will be green.
+
+Each threshold entry is used to define the upper bounds of the threshold. If you don't know the
+upper bound for your version number threshold you will need to provide an extreme upper bound - 
+in this example it is `999.0.0`.
+
 ### Examples
 
 #### Pylint using template
@@ -200,6 +224,11 @@ anybadge --label=pipeline --value=passing --file=pipeline.svg passing=green fail
 anybadge --label=awesomeness --value="110%" --file=awesomeness.svg --color=#97CA00
 ```
 ![pylint](https://cdn.rawgit.com/jongracecox/anybadge/master/examples/awesomeness.svg)
+
+#### Thresholds based on semantic versions
+```bash
+anybadge --label=Version --value=2.4.5 --file=version.svg 1.0.0=red 2.4.6=orange 2.9.1=yellow 999.0.0=green
+```
 
 ### Options
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     py_modules=['anybadge', 'anybadge_server'],
     setup_requires=['setuptools', 'wheel'],
     tests_require=['unittest'],
-    install_requires=[],
+    install_requires=['packaging'],
     data_files=[],
     options={
         'bdist_wheel': {'universal': True}

--- a/tests/test_anybadge.py
+++ b/tests/test_anybadge.py
@@ -242,7 +242,7 @@ class TestAnybadge(TestCase):
 
     def test_str_value_with_threshold_and_default(self):
         badge = Badge('label', value='fred', thresholds={'pass': 'green', 'fail': 'red'}, default_color='orange')
-        self.assertTrue('orange', badge.badge_color)
+        self.assertEqual('orange', badge.badge_color)
 
     def test_invalid_color(self):
         with self.assertRaises(ValueError):
@@ -287,3 +287,34 @@ class TestAnybadge(TestCase):
     def test_main_missing_value(self):
         with self.assertRaisesRegexp(ValueError, r'Label has not been set\.  Please use --label argument\.'):
             main(['--value', '123', '--file', 'test_badge_main.svg', '--overwrite'])
+
+    def test_version_comparison(self):
+        # Define thresholds: <3.0.0=red, <3.2.0=orange <999.0.0=green
+        badge = Badge('Version', value='1.0.0', thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('red', badge.badge_color)
+
+        # Define thresholds: <3.0.0=red, <3.2.0=orange <999.0.0=green
+        badge = Badge('Version', value='3.0.0', thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('orange', badge.badge_color)
+
+        # Define thresholds: <3.0.0=red, <3.2.0=orange <999.0.0=green
+        badge = Badge('Version', value='3.1.0', thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('orange', badge.badge_color)
+
+        # Define thresholds: <3.0.0=red, <3.2.0=orange <999.0.0=green
+        badge = Badge('Version', value='3.2.0', thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('green', badge.badge_color)
+
+        badge = Badge('Version', value='3.2.1', thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('green', badge.badge_color)
+
+        # Define thresholds: <3.0.0=red, <3.2.0=orange <999.0.0=green
+        badge = Badge('Version', value='10.20.30', thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('green', badge.badge_color)
+
+        # Define thresholds: <3.0.0=red, <13.2.0=orange <999.0.0=green
+        badge = Badge('Version', value='14.0.0', thresholds={'3.0.0': 'red', '13.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('green', badge.badge_color)
+
+        badge = Badge('Version', value='12.0.0', thresholds={'3.0.0': 'red', '13.2.0': 'orange', '999.0.0': 'green'}, semver=True)
+        self.assertEqual('orange', badge.badge_color)


### PR DESCRIPTION
# Summary
Allow value and thresholds to be interpreted as semantic version numbers
by passing `--semver` (cli) or `semver=True` (python).

# Details
This commit adds support for color-coded badges based on version numbering. Here are some examples:

```python
badge = Badge(
    label='Version', value='3.0.0',
    thresholds={'3.0.0': 'red', '3.2.0': 'orange', '999.0.0': 'green'},
    semver=True
)
```

In the above example the thresholds equate to the following:

* If value is < 3.0.0 then badge will be red.
* If value is < 3.2.0 then badge will be orange.
* If value is < 999.0.0 then badge will be green.

Each threshold entry is used to define the upper bounds of the threshold. If you don't know the
upper bound for your version number threshold you will need to provide an extreme upper bound - 
in this example it is `999.0.0`.

# Implementation
Behind the scenes this uses [`LooseVersion`](https://stackoverflow.com/a/11887885/6252525) for comparison, which
seems to be a good choice for this exercise.

There is no reliable way to know whether a string is a semantic version, so I chose to add a flag / argument to enable semantic version support. When this option is passed the value and thresholds used in the `badge_color` property are replaced with LooseVersion alternatives. This allows the threshold comparisons to remain largely the same, just operating on values that will return the correct results for semver scenarios.

I added a handful of unittests that test the functionality, with a few that test the edge cases that wouldn't work for string-based version comparison.

# Changes
Add documentation, unittests, import error handling, cli updates, requirements updates.