### PR TITLE
Remove unittest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='jongracecox@gmail.com',
     py_modules=['anybadge', 'anybadge_server'],
     setup_requires=['setuptools', 'wheel'],
-    tests_require=['unittest'],
+    tests_require=[],
     install_requires=['packaging'],
     data_files=[],
     options={


### PR DESCRIPTION
`unittest` is a [standard module](https://docs.python.org/3/library/unittest.html).

It's an issue for distributions. The build process could try to download `unittest` as it's mentioned as a requirement.