### PR TITLE
fix colorto readme typo as that option does not appear to exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ optional arguments:
                         Formatting string for value (e.g. "%.2f" for 2dp
                         floats)
   -c COLOR, --color COLOR
-                        For fixed color badges use --colorto specify the badge
+                        For fixed color badges use --color specify the badge
                         color.
   -p PREFIX, --prefix PREFIX
                         Optional prefix for value.


### PR DESCRIPTION
fix colorto typo as that option does not appear to exist anymore

```
ncrane@ncrane-XPS-15:~/stuff/more_repos/anybadge$ anybadge --label "asdfasdf" -v "asdf" --color blue
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg" width="98" height="20">
    <linearGradient id="b" x2="0" y2="100%">
        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
        <stop offset="1" stop-opacity=".1"/>
    </linearGradient>
    <mask id="anybadge_1">
        <rect width="98" height="20" rx="3" fill="#fff"/>
    </mask>
    <g mask="url(#anybadge_1)">
        <path fill="#555" d="M0 0h62v20H0z"/>
        <path fill="#0000FF" d="M62 0h36v20H62z"/>
        <path fill="url(#b)" d="M0 0h98v20H0z"/>
    </g>
    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
        <text x="32.0" y="15" fill="#010101" fill-opacity=".3">asdfasdf</text>
        <text x="31.0" y="14">asdfasdf</text>
    </g>
    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
        <text x="81.0" y="15" fill="#010101" fill-opacity=".3">asdf</text>
        <text x="80.0" y="14">asdf</text>
    </g>
</svg>
```
```
ncrane@ncrane-XPS-15:~/stuff/more_repos/anybadge$ anybadge --label "asdfasdf" -v "asdf" --colorto blue
usage: anybadge [-h] [-l LABEL] -v VALUE [-m VALUE_FORMAT] [-c COLOR] [-p PREFIX] [-s SUFFIX] [-d PADDING] [-lp LABEL_PADDING]
                [-vp VALUE_PADDING] [-n FONT] [-z FONT_SIZE] [-t TEMPLATE] [-u] [-f FILE] [-o] [-r TEXT_COLOR] [-e]
                ...
anybadge: error: unrecognized arguments: --colorto

```