### PR TITLE
anybadge cli accessible via `python -m`

### DIFF
--- a/anybadge/__main__.py
+++ b/anybadge/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/anybadge/__main__.py
+++ b/anybadge/__main__.py
@@ -1,4 +1,9 @@
 from .cli import main
 
 if __name__ == "__main__":
+    # ensure that `anybadge` shows in usage (not __main__.py)
+    import sys
+
+    sys.argv[0] = "anybadge"
+
     main()

--- a/anybadge/server/__main__.py
+++ b/anybadge/server/__main__.py
@@ -1,0 +1,9 @@
+from .cli import main
+
+if __name__ == "__main__":
+    # ensure that `anybadge-server` shows in usage (not `__main__.py`)
+    import sys
+
+    sys.argv[0] = "anybadge-server"
+
+    main()

--- a/tests/test_anybadge.py
+++ b/tests/test_anybadge.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest import TestCase
 from anybadge import Badge
@@ -403,3 +404,9 @@ class TestAnybadge(TestCase):
             semver=True,
         )
         self.assertEqual("orange", badge.badge_color)
+
+    def test_module_same_output_as_main_cli(self):
+        """Test that `python -m anybadge` is equivalent to calling `anybadge` directly."""
+        output_module = subprocess.check_output(["python", "-m", "anybadge", "--help"])
+        output_script = subprocess.check_output(["anybadge", "--help"])
+        self.assertEqual(output_module, output_script)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,3 +43,11 @@ class TestAnybadgeServer(TestCase):
         self.assertTrue(
             response.content.startswith(b'<?xml version="1.0" encoding="UTF-8"?>\n<svg')
         )
+
+    def test_server_module_same_output_as_server_cli(self):
+        """Test that `python -m anybadge.server` is equivalent to calling `anybadge-server` directly."""
+        output_module = subprocess.check_output(
+            ["python", "-m", "anybadge.server", "--help"]
+        )
+        output_script = subprocess.check_output(["anybadge-server", "--help"])
+        self.assertEqual(output_module, output_script)


### PR DESCRIPTION
## How

Add `__main__.py` file to `anybadge` and `anybadge.server` packages, which is executed when `python -m` is called.

## Before

```sh
$ python -m anybadge   
../bin/python: No module named anybadge.__main__; 'anybadge' is a package and cannot be directly executed
```

## After

```sh
$ python -m anybadge
usage: anybadge [-h] [-l LABEL] -v VALUE [-m VALUE_FORMAT] [-c COLOR] [-p PREFIX] [-s SUFFIX] [-d PADDING] [-lp LABEL_PADDING] [-vp VALUE_PADDING] [-n FONT] [-z FONT_SIZE]
                [-t TEMPLATE] [-st STYLE] [-u] [-f FILE] [-o] [-r TEXT_COLOR] [-e]
                ...
anybadge: error: the following arguments are required: -v/--value
```

Same has been added for `anybadge-server` as well, so that it can be called via `python -m anybadge.server`.

Closes #78 