### PR TITLE
Fix pre-commit on master branch

### DIFF
--- a/.github/workflows/pr_check.yaml
+++ b/.github/workflows/pr_check.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install pre-commit
 
       - name: Run pre-commit
-        run: pre-commit run --all-files
+        run: SKIP=no-commit-to-branch pre-commit run --all-files
 
   python-tests:
     needs: pre-commit


### PR DESCRIPTION
Ignore `no-commit-to-branch` check when running in CI workflow, since this check is only relevant to running locally, and fails when running on master branch in CI workflow.