### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -5,7 +5,7 @@ name: Python package
 on:
   push:
     tags:
-      - 'v*'
+      - "v*.*.*"
 
 jobs:
   release:
@@ -31,13 +31,13 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.0.0
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for the Python package. The changes refine the tag matching pattern and update the versions of actions used.

Updates to GitHub Actions workflow:

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8L8-R8): Changed the tag pattern to match semantic versioning (`v*.*.*`).
* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8L34-R40): Updated the `pypa/gh-action-pypi-publish` action to use the latest major version (`v1`).
* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8L34-R40): Updated the `softprops/action-gh-release` action to the latest major version (`v2`).