### PR TITLE
Fix gh-action-pypi-publish action version

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -31,7 +31,7 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/python-package.yaml` file to update the GitHub Action used for publishing packages to PyPI.

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8L34-R34): Changed the action from `pypa/gh-action-pypi-publish@v1` to `pypa/gh-action-pypi-publish@release/v1` for uploading packages to PyPI.