### PR TITLE
Fix Python release workflow

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -8,7 +8,7 @@ on:
       - "v*.*.*"
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 
@@ -30,6 +30,23 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
 
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/anybadge
+    steps:
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -44,6 +61,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Clean up
-        run: |
-          rm -rf dist
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"
+    - name: Cleanup
+      run: rm -rf dist/


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow for building, publishing, and releasing a Python package. The most important changes involve renaming and restructuring jobs, adding steps to store distribution packages, and implementing a new job for signing and uploading releases to GitHub.

Changes to job names and structure:

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8L11-R11): Renamed the `release` job to `build` and added dependencies between jobs for better workflow organization.

Addition of steps for storing distribution packages:

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8R33-R49): Added steps to the `build` job to store the distribution packages using the `actions/upload-artifact@v4` action.

New job for publishing to PyPI:

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8R33-R49): Introduced a new `publish-to-pypi` job that depends on the `build` job, which handles publishing the package to PyPI.

New job for signing and uploading releases:

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8R64-R107): Added a `github-release` job that signs the distribution packages with Sigstore and uploads them to a GitHub Release. This job depends on the `publish-to-pypi` job.