### PR TITLE
Fix pypi publish authentication

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -56,9 +56,6 @@ jobs:
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/python-package.yaml` file. The change removes the `with` block containing the `user` and `password` fields for the `pypa/gh-action-pypi-publish@release/v1` action.

* [`.github/workflows/python-package.yaml`](diffhunk://#diff-99b88a98efd0677d898beb3aa7118fc2ad81b89c77a1abba84243ffb1d830fa8L59-L61): Removed the `with` block containing the `user` and `password` fields for the `pypa/gh-action-pypi-publish@release/v1` action.