### PR TITLE
Fix label and value escaping

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,28 +7,28 @@ assignees: jongracecox
 
 ---
 
-**Describe the bug**
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
 Provide the simplest example of code or commands to reproduce the behavior.
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-** Python version: (please complete the following information)**
+## Python version: (please complete the following information)
 - 2.7
 - 3.6
 - 3.7
 - ...
 
-** Operating system: (please complete the following information)**
+## Operating system: (please complete the following information)
 - Linux
 - Windows
 - Mac OS
 
-**Additional context**
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: jongracecox
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/workflows/pr_check.yaml
+++ b/.github/workflows/pr_check.yaml
@@ -36,7 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch the entire history including tags
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -351,6 +351,19 @@ Each threshold entry is used to define the upper bounds of the threshold. If you
 upper bound for your version number threshold you will need to provide an extreme upper bound -
 in this example it is `999.0.0`.
 
+### Escaping
+
+Badges are generated as .svg files, which utilize an XML-based markup language. Consequently,
+any HTML characters present in badge labels or values must be escaped to ensure proper
+representation. If you need to disable escaping, the following options are available:
+
+- Python API
+  - `escape_label=False`
+  - `escape_value=False`
+- CLI
+  - `--no-escape-label`
+  - `--no-escape-value`
+
 ### Examples
 
 #### Pylint using template

--- a/anybadge/badge.py
+++ b/anybadge/badge.py
@@ -2,6 +2,7 @@ import os
 from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Type, Optional, Union
+import html
 
 from . import config
 from .colors import Color
@@ -122,6 +123,8 @@ class Badge:
         value_format: Optional[str] = None,
         text_color: Optional[str] = None,
         semver: Optional[bool] = False,
+        escape_label: Optional[bool] = True,
+        escape_value: Optional[bool] = True,
     ):
         """Constructor for Badge class."""
         # Set defaults if values were not passed
@@ -208,6 +211,9 @@ class Badge:
 
         self.use_max_when_value_exceeds = use_max_when_value_exceeds
         self.mask_str = self.__class__._get_next_mask_str()
+
+        self.escape_label = escape_label
+        self.escape_value = escape_value
 
     def __repr__(self) -> str:
         """Return a representation of the Badge object instance.
@@ -332,6 +338,20 @@ class Badge:
                 return file_handle.read()
         else:
             return self.template
+
+    @property
+    def encoded_label(self) -> str:
+        if self.escape_label:
+            return html.escape(self.label)
+        else:
+            return self.label
+
+    @property
+    def encoded_value(self) -> str:
+        if self.escape_value:
+            return html.escape(self.value_text)
+        else:
+            return self.value_text
 
     @property
     def semver_version(self) -> Version:
@@ -638,8 +658,8 @@ class Badge:
             badge_text.replace("{{ badge width }}", str(self.badge_width))
             .replace("{{ font name }}", self.font_name)
             .replace("{{ font size }}", str(self.font_size))
-            .replace("{{ label }}", self.label)
-            .replace("{{ value }}", self.value_text)
+            .replace("{{ label }}", self.encoded_label)
+            .replace("{{ value }}", self.encoded_value)
             .replace("{{ label anchor }}", str(self.label_anchor))
             .replace("{{ label anchor shadow }}", str(self.label_anchor_shadow))
             .replace("{{ value anchor }}", str(self.value_anchor))

--- a/anybadge/cli.py
+++ b/anybadge/cli.py
@@ -156,6 +156,18 @@ examples:
         help="Treat value and thresholds as semantic versions.",
     )
     parser.add_argument(
+        "--no-escape-label",
+        action="store_true",
+        default=False,
+        help="Do not escape the label text.",
+    )
+    parser.add_argument(
+        "--no-escape-value",
+        action="store_true",
+        default=False,
+        help="Do not escape the value text.",
+    )
+    parser.add_argument(
         "args",
         nargs=argparse.REMAINDER,
         help="Pairs of <upper>=<color>. "
@@ -217,6 +229,8 @@ def main(args=None):
         value_format=args.value_format,
         text_color=args.text_color,
         semver=args.semver,
+        escape_label=not args.no_escape_label,
+        escape_value=not args.no_escape_value,
     )
 
     if args.file:

--- a/anybadge/cli.py
+++ b/anybadge/cli.py
@@ -177,8 +177,12 @@ examples:
     return parser.parse_args(args)
 
 
-def main(args=None):
-    """Generate a badge based on command line arguments."""
+def main(args=None) -> int:
+    """Generate a badge based on command line arguments.
+
+    Returns:
+        int: 0 if successful, 1 otherwise.
+    """
 
     # Args may be sent from command line of as args directly.
     if not args:
@@ -186,7 +190,7 @@ def main(args=None):
 
     if args == ["--version"]:
         print(anybadge_version)
-        return
+        return 0
 
     # Parse command line arguments
     args = parse_args(args)
@@ -207,8 +211,13 @@ def main(args=None):
             suffix = style.suffix
 
     # Create threshold list from args
-    threshold_list = [x.split("=") for x in threshold_text]
-    threshold_dict = {x[0]: x[1] for x in threshold_list}
+    try:
+        threshold_list = [x.split("=") for x in threshold_text]
+        threshold_dict = {x[0]: x[1] for x in threshold_list}
+    except Exception as e:
+        print(f"ERROR: Failed to parse threshold values: '{' '.join(threshold_text)}'")
+        print(f"ERROR: Thresholds should be in the form '<value>=color'")
+        return 1
 
     # Create badge object
     badge = Badge(
@@ -239,6 +248,9 @@ def main(args=None):
     else:
         print(badge.badge_svg_text)
 
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    retval = main()
+    sys.exit(retval)

--- a/anybadge/helpers.py
+++ b/anybadge/helpers.py
@@ -1,3 +1,34 @@
+import re
+
+
+EMOJI_REGEX = re.compile(
+    "["
+    "\U0001F600-\U0001F64F"  # emoticons
+    "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    "\U0001F680-\U0001F6FF"  # transport & map symbols
+    "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+    "\U00002702-\U000027B0"  # Dingbats
+    "\U000024C2-\U0001F251"
+    "]+",
+    flags=re.UNICODE,
+)
+
+
+def is_emoji(character):
+    """Return True if character is an emoji.
+
+    Examples:
+
+        >>> is_emoji('👍')
+        True
+
+        >>> is_emoji('a')
+        False
+
+    """
+    return bool(EMOJI_REGEX.match(character))
+
+
 # Based on the following SO answer: https://stackoverflow.com/a/16008023/6252525
 def _get_approx_string_width(text, font_width, fixed_width=False) -> int:
     """
@@ -52,11 +83,14 @@ def _get_approx_string_width(text, font_width, fixed_width=False) -> int:
     }
 
     for s in text:
-        percentage = 100.0
-        for k in char_width_percentages.keys():
-            if s in k:
-                percentage = char_width_percentages[k]
-                break
+        percentage = 50.0
+        if is_emoji(s):
+            percentage = 75.0
+        else:
+            for k in char_width_percentages.keys():
+                if s in k:
+                    percentage = char_width_percentages[k]
+                    break
         size += (percentage / 100.0) * float(font_width)
 
     return int(size)

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -5,6 +5,7 @@ pytest
 pytest-cov
 requests
 setuptools
+sh
 tox
 types-requests
 wheel

--- a/tasks/colors.py
+++ b/tasks/colors.py
@@ -4,12 +4,12 @@ import requests
 from invoke import task
 from bs4 import BeautifulSoup
 
-from anybadge.colors import Color
-
 
 @task
 def update(c):
     """Generate colors Enum from Mozilla color keywords."""
+    from anybadge.colors import Color
+
     url = "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color_keywords"
     response = requests.get(url)
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -38,7 +38,8 @@ def local(c):
     retval = 0
     try:
         subprocess.run(
-            f"{sys.executable} -m pytest --doctest-modules --cov=anybadge --cov-report html:htmlcov anybadge tests",
+            f"{sys.executable} -m pytest --doctest-modules "
+            "--cov=anybadge --cov-report term --cov-report html:htmlcov --cov-report xml:coverage.xml anybadge tests",
             shell=True,
         )
     except Exception as e:

--- a/tests/test_anybadge.py
+++ b/tests/test_anybadge.py
@@ -461,3 +461,34 @@ class TestAnybadge(TestCase):
                 label=None,
                 value=None,
             )
+
+    def test_badge_default_escaping(self):
+        """Test explicitly using value and label escaping for the badge."""
+        badge = Badge(
+            label="My > Label",
+            value="My > Value",
+        )
+        self.assertEqual(badge.encoded_label, "My &gt; Label")
+        self.assertEqual(badge.encoded_value, "My &gt; Value")
+
+    def test_badge_explicit_escaping(self):
+        """Test explicitly using value and label escaping for the badge."""
+        badge = Badge(
+            label="My > Label",
+            value="My > Value",
+            escape_label=True,
+            escape_value=True,
+        )
+        self.assertEqual(badge.encoded_label, "My &gt; Label")
+        self.assertEqual(badge.encoded_value, "My &gt; Value")
+
+    def test_badge_without_escaping(self):
+        """Test switching off value and label escaping for the badge."""
+        badge = Badge(
+            label="My > Label",
+            value="My > Value",
+            escape_label=False,
+            escape_value=False,
+        )
+        self.assertEqual(badge.encoded_label, "My > Label")
+        self.assertEqual(badge.encoded_value, "My > Value")

--- a/tests/test_anybadge.py
+++ b/tests/test_anybadge.py
@@ -3,9 +3,12 @@ from pathlib import Path
 from unittest import TestCase
 from anybadge import Badge
 from anybadge.cli import main, parse_args
+import sys
 
+import sh
 
 TESTS_DIR = Path(__file__).parent
+PROJECT_ROOT = TESTS_DIR.parent
 
 
 class TestAnybadge(TestCase):
@@ -401,8 +404,20 @@ class TestAnybadge(TestCase):
 
     def test_module_same_output_as_main_cli(self):
         """Test that `python -m anybadge` is equivalent to calling `anybadge` directly."""
-        output_module = subprocess.check_output(["python", "-m", "anybadge", "--help"])
-        output_script = subprocess.check_output(["anybadge", "--help"])
+
+        python_executable = sys.executable
+        anybadge_executable = Path(python_executable).parent / "anybadge"
+
+        python_cmd = sh.Command(sys.executable)
+
+        env = {
+            "PYTHONPATH": str(PROJECT_ROOT),
+        }
+        output_module = python_cmd("-m", "anybadge", "--help", _env=env)
+
+        anybadge_executable = Path(python_executable).parent / "anybadge"
+        output_script = sh.Command(anybadge_executable)("--help")
+
         self.assertEqual(output_module, output_script)
 
     def test_badge_with_no_label(self):


### PR DESCRIPTION
Fix label and value escaping by defaulting to html escaping them. Provide Python and CLI args to allow reverting to old behavior of not escaping.

Fixes #91